### PR TITLE
Improve performance for MPS implements

### DIFF
--- a/src/backend/mps/backend.rs
+++ b/src/backend/mps/backend.rs
@@ -10,16 +10,14 @@ use metal::objc::rc::autoreleasepool;
 pub struct MpsBackend {
     device: Arc<MpsDevice>,
     compute: MpsCompute,
-    minimum_mps_compute_size: usize
 }
 
 impl MpsBackend {
     pub fn new() -> MlResult<Self> {
         let device = Arc::new(MpsDevice::new().expect("Failed to create MPS device"));
         let compute = MpsCompute::new(Arc::clone(&device)).expect("Failed to create MPS compute");
-        let minimum_mps_compute_size = 256;
 
-        Ok(Self { device, compute, minimum_mps_compute_size })
+        Ok(Self { device, compute })
     }
 }
 
@@ -211,11 +209,6 @@ impl Backend for MpsBackend {
     }
 
     fn sum(&self, a: &[f32]) -> f32 {
-        if a.len() < self.minimum_mps_compute_size {
-            // fallback to cpu compute
-
-        } 
-
         let mut result_slice: &[f32] = &[];
 
         autoreleasepool(|| {

--- a/src/backend/mps/backend.rs
+++ b/src/backend/mps/backend.rs
@@ -1,8 +1,7 @@
-use super::{MpsCompute, MpsDevice, MpsError};
-use crate::backend::feature::{DeviceFeatures, GPU_FEATURE_FP16, GPU_FEATURE_FP64};
+use super::{MpsCompute, MpsDevice};
+use crate::backend::feature::DeviceFeatures;
 use crate::backend::{Backend, Device, DeviceType};
 use crate::MlResult;
-use metal::{Buffer, MTLResourceOptions, MTLSize};
 use std::fmt::Debug;
 use std::sync::Arc;
 use metal::objc::rc::autoreleasepool;
@@ -11,348 +10,16 @@ use metal::objc::rc::autoreleasepool;
 pub struct MpsBackend {
     device: Arc<MpsDevice>,
     compute: MpsCompute,
+    minimum_mps_compute_size: usize
 }
 
 impl MpsBackend {
     pub fn new() -> MlResult<Self> {
         let device = Arc::new(MpsDevice::new().expect("Failed to create MPS device"));
         let compute = MpsCompute::new(Arc::clone(&device)).expect("Failed to create MPS compute");
+        let minimum_mps_compute_size = 256;
 
-        Ok(Self { device, compute })
-    }
-
-    pub fn create_buffer<T: Copy>(&self, data: &[T]) -> Result<Buffer, MpsError> {
-        let buffer = self.device.device().new_buffer_with_data(
-            data.as_ptr() as *const _,
-            (data.len() * std::mem::size_of::<T>()) as u64,
-            MTLResourceOptions::StorageModeShared,
-        );
-
-        Ok(buffer)
-    }
-
-    pub fn matmul(
-        &self,
-        a: &Buffer,
-        b: &Buffer,
-        m: usize,
-        n: usize,
-        k: usize,
-    ) -> Result<Buffer, MpsError> {
-        if m == 0 || n == 0 || k == 0 {
-            return Err(MpsError::InvalidDimensions);
-        }
-
-        let result_size = m * k * std::mem::size_of::<f32>();
-        let result_buffer = self
-            .device
-            .device()
-            .new_buffer(result_size as u64, MTLResourceOptions::StorageModeShared);
-
-        // Create dimension buffers
-        let m_buffer = self.create_buffer(&[m as u32])?;
-        let n_buffer = self.create_buffer(&[n as u32])?;
-        let k_buffer = self.create_buffer(&[k as u32])?;
-
-        let library = self
-            .device
-            .device()
-            .new_library_with_source(
-                include_str!("../../../shaders/metal/matrix_ops.metal"),
-                &metal::CompileOptions::new(),
-            )
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let kernel = library
-            .get_function("matrix_multiply", None)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let pipeline = self
-            .device
-            .device()
-            .new_compute_pipeline_state_with_function(&kernel)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let thread_group_size = MTLSize::new(16, 16, 1);
-        let grid_size = MTLSize::new(
-            (m + 16) as u64, // ceil(m / threads_per_group_x)
-            (k + 16) as u64, // ceil(n / threads_per_group_y)
-            1, // Only one layer in the z-dimension
-        );
-
-
-        let command_queue = self.device.device().new_command_queue();
-        let command_buffer = command_queue.new_command_buffer();
-        let compute_encoder = command_buffer.new_compute_command_encoder();
-
-        compute_encoder.set_compute_pipeline_state(&pipeline);
-        compute_encoder.set_buffer(0, Some(a), 0);
-        compute_encoder.set_buffer(1, Some(b), 0);
-        compute_encoder.set_buffer(2, Some(&result_buffer), 0);
-        compute_encoder.set_buffer(3, Some(&m_buffer), 0);
-        compute_encoder.set_buffer(4, Some(&n_buffer), 0);
-        compute_encoder.set_buffer(5, Some(&k_buffer), 0);
-
-        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
-        compute_encoder.end_encoding();
-
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
-
-        Ok(result_buffer)
-    }
-
-    pub fn add(&self, a: &Buffer, b: &Buffer, size: usize) -> Result<Buffer, MpsError> {
-        let result_buffer = self
-            .device
-            .device()
-            .new_buffer(
-                (size * size_of::<f32>()) as u64,
-                MTLResourceOptions::StorageModeShared,
-            );
-
-        // Create and compile the addition kernel
-        let library = self
-            .device
-            .device()
-            .new_library_with_source(
-                include_str!("../../../shaders/metal/binary_ops.metal"),
-                &metal::CompileOptions::new(),
-            )
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let kernel = library
-            .get_function("vector_add", None)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let pipeline = self
-            .device
-            .device()
-            .new_compute_pipeline_state_with_function(&kernel)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        // Configure thread groups
-        let thread_group_size = MTLSize::new(256, 1, 1);
-        let grid_size = MTLSize::new(((size + 255) / 256) as u64, 1, 1);
-
-        let command_queue = self.device.device().new_command_queue();
-        let command_buffer = command_queue.new_command_buffer();
-        let compute_encoder = command_buffer.new_compute_command_encoder();
-
-        compute_encoder.set_compute_pipeline_state(&pipeline);
-        compute_encoder.set_buffer(0, Some(a), 0);
-        compute_encoder.set_buffer(1, Some(b), 0);
-        compute_encoder.set_buffer(2, Some(&result_buffer), 0);
-
-        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
-        compute_encoder.end_encoding();
-
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
-
-        Ok(result_buffer)
-    }
-
-    pub fn sub(&self, a: &Buffer, b: &Buffer, size: usize) -> Result<Buffer, MpsError> {
-        let result_buffer = self
-            .device
-            .device()
-            .new_buffer(
-                (size * std::mem::size_of::<f32>()) as u64,
-                MTLResourceOptions::StorageModeShared,
-            );
-
-        // Create and compile the addition kernel
-        let library = self
-            .device
-            .device()
-            .new_library_with_source(
-                include_str!("../../../shaders/metal/binary_ops.metal"),
-                &metal::CompileOptions::new(),
-            )
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let kernel = library
-            .get_function("vector_sub", None)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let pipeline = self
-            .device
-            .device()
-            .new_compute_pipeline_state_with_function(&kernel)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        // Configure thread groups
-        let thread_group_size = MTLSize::new(256, 1, 1);
-        let grid_size = MTLSize::new(((size + 255) / 256) as u64, 1, 1);
-
-        let command_queue = self.device.device().new_command_queue();
-        let command_buffer = command_queue.new_command_buffer();
-        let compute_encoder = command_buffer.new_compute_command_encoder();
-
-        compute_encoder.set_compute_pipeline_state(&pipeline);
-        compute_encoder.set_buffer(0, Some(a), 0);
-        compute_encoder.set_buffer(1, Some(b), 0);
-        compute_encoder.set_buffer(2, Some(&result_buffer), 0);
-
-        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
-        compute_encoder.end_encoding();
-
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
-
-        Ok(result_buffer)
-    }
-
-    pub fn multiply(&self, a: &Buffer, b: &Buffer, size: usize) -> Result<Buffer, MpsError> {
-        let result_buffer = self
-            .device
-            .device()
-            .new_buffer(
-                (size * std::mem::size_of::<f32>()) as u64,
-                MTLResourceOptions::StorageModeShared,
-            );
-
-        let library = self
-            .device
-            .device()
-            .new_library_with_source(
-                include_str!("../../../shaders/metal/binary_ops.metal"),
-                &metal::CompileOptions::new(),
-            )
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let kernel = library
-            .get_function("vector_mul", None)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let pipeline = self
-            .device
-            .device()
-            .new_compute_pipeline_state_with_function(&kernel)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let thread_group_size = MTLSize::new(256, 1, 1);
-        let grid_size = MTLSize::new(((size + 255) / 256) as u64, 1, 1);
-
-        let command_queue = self.device.device().new_command_queue();
-        let command_buffer = command_queue.new_command_buffer();
-        let compute_encoder = command_buffer.new_compute_command_encoder();
-
-        compute_encoder.set_compute_pipeline_state(&pipeline);
-        compute_encoder.set_buffer(0, Some(a), 0);
-        compute_encoder.set_buffer(1, Some(b), 0);
-        compute_encoder.set_buffer(2, Some(&result_buffer), 0);
-
-        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
-        compute_encoder.end_encoding();
-
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
-
-        Ok(result_buffer)
-    }
-
-    pub fn log(&self, a: &Buffer, size: usize) -> Result<Buffer, MpsError> {
-        let result_buffer = self
-            .device
-            .device()
-            .new_buffer(
-                (size * std::mem::size_of::<f32>()) as u64,
-                MTLResourceOptions::StorageModeShared,
-            );
-
-        // Create and compile the addition kernel
-        let library = self
-            .device
-            .device()
-            .new_library_with_source(
-                include_str!("../../../shaders/metal/binary_ops.metal"),
-                &metal::CompileOptions::new(),
-            )
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let kernel = library
-            .get_function("vector_log", None)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let pipeline = self
-            .device
-            .device()
-            .new_compute_pipeline_state_with_function(&kernel)
-            .map_err(|_| MpsError::ShaderCompilationError)?;
-
-        // Configure thread groups
-        let thread_group_size = MTLSize::new(256, 1, 1);
-        let grid_size = MTLSize::new(((size + 255) / 256) as u64, 1, 1);
-
-        let command_queue = self.device.device().new_command_queue();
-        let command_buffer = command_queue.new_command_buffer();
-        let compute_encoder = command_buffer.new_compute_command_encoder();
-
-        compute_encoder.set_compute_pipeline_state(&pipeline);
-        compute_encoder.set_buffer(0, Some(a), 0);
-        compute_encoder.set_buffer(1, Some(&result_buffer), 0);
-
-        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
-        compute_encoder.end_encoding();
-
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
-
-        Ok(result_buffer)
-    }
-
-    pub fn get_supported_features(&self) -> DeviceFeatures {
-        let mut features = DeviceFeatures::new();
-
-        // Check MPS-specific features
-        features.add_feature(
-            GPU_FEATURE_FP16,
-            true, // MPS supports FP16
-            Some("Half-precision floating point support".to_string()),
-        );
-
-        features.add_feature(
-            GPU_FEATURE_FP64,
-            false, // MPS typically doesn't support FP64
-            Some("Double-precision floating point support".to_string()),
-        );
-
-        features
-    }
-
-    pub fn sum_backend(&self, input: &Buffer, size: usize) -> Result<Buffer, MpsError> {
-        let result_buffer = self.device.device().new_buffer(
-            (size * std::mem::size_of::<f32>()) as u64,
-            MTLResourceOptions::StorageModeShared,
-        );
-
-        let library = self.device.device().new_library_with_source(
-            include_str!("../../../shaders/metal/binary_ops.metal"),
-            &metal::CompileOptions::new(),
-        ).map_err(|_| MpsError::ShaderCompilationError)?;
-
-        let kernel = library.get_function("vector_sum", None).map_err(|_| MpsError::ShaderCompilationError)?;
-        let pipeline = self.device.device().new_compute_pipeline_state_with_function(&kernel).map_err(|_| MpsError::ShaderCompilationError)?;
-        let thread_group_size = MTLSize::new(1, 1, 1);
-        let grid_size = MTLSize::new(1, 1, 1);
-
-        let command_queue = self.device.device().new_command_queue();
-        let command_buffer = command_queue.new_command_buffer();
-        let compute_encoder = command_buffer.new_compute_command_encoder();
-
-        compute_encoder.set_compute_pipeline_state(&pipeline);
-        compute_encoder.set_buffer(0, Some(input), 0);
-        compute_encoder.set_buffer(1, Some(&result_buffer), 0);
-
-        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
-        compute_encoder.end_encoding();
-
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
-
-        Ok(result_buffer)
+        Ok(Self { device, compute, minimum_mps_compute_size })
     }
 }
 
@@ -376,11 +43,11 @@ impl Backend for MpsBackend {
 
         autoreleasepool(|| {
             // Create Buffers on Apple MPS
-            let buffer_a = self.create_buffer(a).expect("Failed to create buffer A");
-            let buffer_b = self.create_buffer(b).expect("Failed to create buffer B");
+            let buffer_a = self.compute.create_buffer(a).expect("Failed to create buffer A");
+            let buffer_b = self.compute.create_buffer(b).expect("Failed to create buffer B");
 
             // Perform addition on Apple MPS
-            let result_buffer = self.add(&buffer_a, &buffer_b, a.len()).expect("Failed to add buffers");
+            let result_buffer = self.compute.add(&buffer_a, &buffer_b, a.len()).expect("Failed to add buffers");
 
             // Read result buffer
             let result = result_buffer.contents();
@@ -398,11 +65,11 @@ impl Backend for MpsBackend {
 
         autoreleasepool(|| {
             // Create Buffers on Apple MPS
-            let buffer_a = self.create_buffer(a).expect("Failed to create buffer A");
-            let buffer_b = self.create_buffer(b).expect("Failed to create buffer B");
+            let buffer_a = self.compute.create_buffer(a).expect("Failed to create buffer A");
+            let buffer_b = self.compute.create_buffer(b).expect("Failed to create buffer B");
 
             // Perform multiplication on Apple MPS
-            let result_buffer = self.multiply(&buffer_a, &buffer_b, a.len()).expect("Failed to multiply buffers");
+            let result_buffer = self.compute.multiply(&buffer_a, &buffer_b, a.len()).expect("Failed to multiply buffers");
 
             // Read result buffer
             let result = result_buffer.contents();
@@ -420,11 +87,11 @@ impl Backend for MpsBackend {
 
         autoreleasepool(|| {
             // Create Buffers on Apple MPS
-            let buffer_a = self.create_buffer(a).expect("Failed to create buffer A");
-            let buffer_b = self.create_buffer(b).expect("Failed to create buffer B");
+            let buffer_a = self.compute.create_buffer(a).expect("Failed to create buffer A");
+            let buffer_b = self.compute.create_buffer(b).expect("Failed to create buffer B");
 
             // Perform matrix multiplication on Apple MPS
-            let result_buffer = self.matmul(&buffer_a, &buffer_b, m, n, k).expect("Failed to multiply matrices");
+            let result_buffer = self.compute.matmul(&buffer_a, &buffer_b, m, n, k).expect("Failed to multiply matrices");
 
             // Read result buffer
             let result = result_buffer.contents();
@@ -444,11 +111,11 @@ impl Backend for MpsBackend {
 
         autoreleasepool(|| {
             // Create Buffers on Apple MPS
-            let buffer_a = self.create_buffer(a).expect("Failed to create buffer A");
-            let buffer_b = self.create_buffer(b).expect("Failed to create buffer B");
+            let buffer_a = self.compute.create_buffer(a).expect("Failed to create buffer A");
+            let buffer_b = self.compute.create_buffer(b).expect("Failed to create buffer B");
 
             // Perform division on Apple MPS
-            let result_buffer = self.add(&buffer_a, &buffer_b, a.len()).expect("Failed to divide buffers");
+            let result_buffer = self.compute.add(&buffer_a, &buffer_b, a.len()).expect("Failed to divide buffers");
 
             // Read result buffer
             let result = result_buffer.contents();
@@ -466,11 +133,11 @@ impl Backend for MpsBackend {
 
         autoreleasepool(|| {
             // Create Buffers on Apple MPS
-            let buffer_a = self.create_buffer(a).expect("Failed to create buffer A");
-            let buffer_b = self.create_buffer(b).expect("Failed to create buffer B");
+            let buffer_a = self.compute.create_buffer(a).expect("Failed to create buffer A");
+            let buffer_b = self.compute.create_buffer(b).expect("Failed to create buffer B");
 
             // Perform subtraction on Apple MPS
-            let result_buffer = self.sub(&buffer_a, &buffer_b, a.len()).expect("Failed to subtract buffers");
+            let result_buffer = self.compute.sub(&buffer_a, &buffer_b, a.len()).expect("Failed to subtract buffers");
 
             // Read result buffer
             let result = result_buffer.contents();
@@ -484,7 +151,19 @@ impl Backend for MpsBackend {
     }
 
     fn exp(&self, a: &[f32]) -> Vec<f32> {
-        todo!()
+        // TODO: consider implementing optimized power operations on the metal backend
+        // using cpu compute code for now
+        let mut result = Vec::with_capacity(a.len());
+        for &x in a {
+            if x > 88.0 {
+                result.push(f32::INFINITY);
+            } else if x < -88.0 {
+                result.push(0.0);
+            } else {
+                result.push(x.exp());
+            }
+        }
+        result
     }
 
     fn log(&self, a: &[f32]) -> Vec<f32> {
@@ -492,10 +171,10 @@ impl Backend for MpsBackend {
 
         autoreleasepool(|| {
             // Create Buffers on Apple MPS
-            let buffer_a = self.create_buffer(a).expect("Failed to create buffer A");
+            let buffer_a = self.compute.create_buffer(a).expect("Failed to create buffer A");
 
             // Perform log on Apple MPS
-            let result_buffer = self.log(&buffer_a, a.len()).expect("Failed to log buffer");
+            let result_buffer = self.compute.log(&buffer_a, a.len()).expect("Failed to log buffer");
 
             // Read result buffer
             let result = result_buffer.contents();
@@ -509,22 +188,44 @@ impl Backend for MpsBackend {
     }
 
     fn pow(&self, a: &[f32], power: f32) -> Vec<f32> {
-        todo!()
+        // TODO: consider implementing optimized power operations on the metal backend
+        // using cpu compute code for now
+        if power == 2.0 {
+            return a.iter().map(|x| x * x).collect();
+        }
+        if power == 0.5 {
+            return self.sqrt(a);
+        }
+
+        a.iter().map(|x| x.powf(power)).collect()
     }
 
     fn sqrt(&self, a: &[f32]) -> Vec<f32> {
-        todo!()
+        // TODO: consider implementing optimized power operations on the metal backend
+        // using cpu compute code for now
+        let mut result = Vec::with_capacity(a.len());
+        for &x in a {
+            result.push(if x < 0.0 { f32::NAN } else { x.sqrt() });
+        }
+        result
     }
 
     fn sum(&self, a: &[f32]) -> f32 {
+        if a.len() < self.minimum_mps_compute_size {
+            // fallback to cpu compute
+
+        } else {
+
+        }
+
         let mut result_slice: &[f32] = &[];
 
         autoreleasepool(|| {
             // Create Buffers on Apple MPS
-            let buffer_a = self.create_buffer(a).expect("Failed to create buffer A");
+            let buffer_a = self.compute.create_buffer(a).expect("Failed to create buffer A");
 
             // Perform sum on Apple MPS
-            let result_buffer = self.sum_backend(&buffer_a, a.len()).expect("Failed to sum buffer");
+            let result_buffer = self.compute.sum_backend(&buffer_a, a.len()).expect("Failed to sum buffer");
 
             // Read result buffer
             let result = result_buffer.contents();
@@ -561,6 +262,6 @@ impl Device for MpsBackend {
     }
 
     fn get_features(&self) -> DeviceFeatures {
-        self.get_supported_features()
+        self.compute.get_supported_features()
     }
 }

--- a/src/backend/mps/backend.rs
+++ b/src/backend/mps/backend.rs
@@ -1,3 +1,5 @@
+use metal::objc::rc::autoreleasepool;
+
 use super::{MpsCompute, MpsDevice};
 use crate::backend::feature::DeviceFeatures;
 use crate::backend::{Backend, Device, DeviceType};

--- a/src/backend/mps/backend.rs
+++ b/src/backend/mps/backend.rs
@@ -96,7 +96,7 @@ impl Backend for MpsBackend {
             // Read result buffer
             let result = result_buffer.contents();
             let result_slice = unsafe {
-                std::slice::from_raw_parts(result as *const f32, (m * k))
+                std::slice::from_raw_parts(result as *const f32, m * k)
             };
 
             // Copy result to a Vec
@@ -214,9 +214,7 @@ impl Backend for MpsBackend {
         if a.len() < self.minimum_mps_compute_size {
             // fallback to cpu compute
 
-        } else {
-
-        }
+        } 
 
         let mut result_slice: &[f32] = &[];
 

--- a/src/backend/mps/compute.rs
+++ b/src/backend/mps/compute.rs
@@ -1,5 +1,7 @@
-use super::core::MpsDevice;
-use metal::{CommandQueue, ComputePipelineState, MTLSize};
+use crate::backend::{feature::{GPU_FEATURE_FP16, GPU_FEATURE_FP64}, DeviceFeatures};
+
+use super::{core::MpsDevice, MpsError};
+use metal::{Buffer, CommandQueue, ComputePipelineState, MTLResourceOptions, MTLSize};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -20,23 +22,351 @@ impl MpsCompute {
         })
     }
 
-    pub fn dispatch_compute(
+    pub fn create_buffer<T: Copy>(&self, data: &[T]) -> Result<Buffer, MpsError> {
+        let buffer = self.device.device().new_buffer_with_data(
+            data.as_ptr() as *const _,
+            (data.len() * std::mem::size_of::<T>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        Ok(buffer)
+    }
+
+    // pub fn dispatch_compute(
+    //     &self,
+    //     pipeline: &ComputePipelineState,
+    //     grid_size: MTLSize,
+    //     thread_group_size: MTLSize,
+    // ) -> Result<(), crate::backend::MpsError> {
+    //     let command_buffer = self.command_queue.new_command_buffer();
+    //     let compute_encoder = command_buffer.new_compute_command_encoder();
+
+    //     compute_encoder.set_compute_pipeline_state(pipeline);
+    //     compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
+    //     compute_encoder.end_encoding();
+
+    //     command_buffer.commit();
+    //     command_buffer.wait_until_completed();
+
+    //     Ok(())
+    // }
+
+
+    pub fn matmul(
         &self,
-        pipeline: &ComputePipelineState,
-        grid_size: MTLSize,
-        thread_group_size: MTLSize,
-    ) -> Result<(), crate::backend::MpsError> {
+        a: &Buffer,
+        b: &Buffer,
+        m: usize,
+        n: usize,
+        k: usize,
+    ) -> Result<Buffer, MpsError> {
+        if m == 0 || n == 0 || k == 0 {
+            return Err(MpsError::InvalidDimensions);
+        }
+
+        let result_size = m * k * std::mem::size_of::<f32>();
+        let result_buffer = self
+            .device
+            .device()
+            .new_buffer(result_size as u64, MTLResourceOptions::StorageModeShared);
+
+        // Create dimension buffers
+        let m_buffer = self.create_buffer(&[m as u32])?;
+        let n_buffer = self.create_buffer(&[n as u32])?;
+        let k_buffer = self.create_buffer(&[k as u32])?;
+
+        let library = self
+            .device
+            .device()
+            .new_library_with_source(
+                include_str!("../../../shaders/metal/matrix_ops.metal"),
+                &metal::CompileOptions::new(),
+            )
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let kernel = library
+            .get_function("matrix_multiply", None)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let pipeline = self
+            .device
+            .device()
+            .new_compute_pipeline_state_with_function(&kernel)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let thread_group_size = MTLSize::new(16, 16, 1);
+        let grid_size = MTLSize::new(
+            (m + 16) as u64, // ceil(m / threads_per_group_x)
+            (k + 16) as u64, // ceil(n / threads_per_group_y)
+            1, // Only one layer in the z-dimension
+        );
+
         let command_buffer = self.command_queue.new_command_buffer();
         let compute_encoder = command_buffer.new_compute_command_encoder();
 
-        compute_encoder.set_compute_pipeline_state(pipeline);
+        compute_encoder.set_compute_pipeline_state(&pipeline);
+        compute_encoder.set_buffer(0, Some(a), 0);
+        compute_encoder.set_buffer(1, Some(b), 0);
+        compute_encoder.set_buffer(2, Some(&result_buffer), 0);
+        compute_encoder.set_buffer(3, Some(&m_buffer), 0);
+        compute_encoder.set_buffer(4, Some(&n_buffer), 0);
+        compute_encoder.set_buffer(5, Some(&k_buffer), 0);
+
         compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
         compute_encoder.end_encoding();
 
         command_buffer.commit();
         command_buffer.wait_until_completed();
 
-        Ok(())
+        Ok(result_buffer)
+    }
+
+    pub fn add(&self, a: &Buffer, b: &Buffer, size: usize) -> Result<Buffer, MpsError> {
+        let result_buffer = self
+            .device
+            .device()
+            .new_buffer(
+                (size * size_of::<f32>()) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+
+        // Create and compile the addition kernel
+        let library = self
+            .device
+            .device()
+            .new_library_with_source(
+                include_str!("../../../shaders/metal/binary_ops.metal"),
+                &metal::CompileOptions::new(),
+            )
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let kernel = library
+            .get_function("vector_add", None)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let pipeline = self
+            .device
+            .device()
+            .new_compute_pipeline_state_with_function(&kernel)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        // Configure thread groups
+        let thread_group_size = MTLSize::new(256, 1, 1);
+        let grid_size = MTLSize::new(((size + 255) / 256) as u64, 1, 1);
+
+        let command_buffer = self.command_queue.new_command_buffer();
+        let compute_encoder = command_buffer.new_compute_command_encoder();
+
+        compute_encoder.set_compute_pipeline_state(&pipeline);
+        compute_encoder.set_buffer(0, Some(a), 0);
+        compute_encoder.set_buffer(1, Some(b), 0);
+        compute_encoder.set_buffer(2, Some(&result_buffer), 0);
+
+        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
+        compute_encoder.end_encoding();
+
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+
+        Ok(result_buffer)
+    }
+
+    pub fn sub(&self, a: &Buffer, b: &Buffer, size: usize) -> Result<Buffer, MpsError> {
+        let result_buffer = self
+            .device
+            .device()
+            .new_buffer(
+                (size * std::mem::size_of::<f32>()) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+
+        // Create and compile the addition kernel
+        let library = self
+            .device
+            .device()
+            .new_library_with_source(
+                include_str!("../../../shaders/metal/binary_ops.metal"),
+                &metal::CompileOptions::new(),
+            )
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let kernel = library
+            .get_function("vector_sub", None)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let pipeline = self
+            .device
+            .device()
+            .new_compute_pipeline_state_with_function(&kernel)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        // Configure thread groups
+        let thread_group_size = MTLSize::new(256, 1, 1);
+        let grid_size = MTLSize::new(((size + 255) / 256) as u64, 1, 1);
+
+        let command_buffer = self.command_queue.new_command_buffer();
+        let compute_encoder = command_buffer.new_compute_command_encoder();
+
+        compute_encoder.set_compute_pipeline_state(&pipeline);
+        compute_encoder.set_buffer(0, Some(a), 0);
+        compute_encoder.set_buffer(1, Some(b), 0);
+        compute_encoder.set_buffer(2, Some(&result_buffer), 0);
+
+        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
+        compute_encoder.end_encoding();
+
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+
+        Ok(result_buffer)
+    }
+
+    pub fn multiply(&self, a: &Buffer, b: &Buffer, size: usize) -> Result<Buffer, MpsError> {
+        let result_buffer = self
+            .device
+            .device()
+            .new_buffer(
+                (size * std::mem::size_of::<f32>()) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+
+        let library = self
+            .device
+            .device()
+            .new_library_with_source(
+                include_str!("../../../shaders/metal/binary_ops.metal"),
+                &metal::CompileOptions::new(),
+            )
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let kernel = library
+            .get_function("vector_mul", None)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let pipeline = self
+            .device
+            .device()
+            .new_compute_pipeline_state_with_function(&kernel)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let thread_group_size = MTLSize::new(256, 1, 1);
+        let grid_size = MTLSize::new(((size + 255) / 256) as u64, 1, 1);
+
+        let command_buffer = self.command_queue.new_command_buffer();
+        let compute_encoder = command_buffer.new_compute_command_encoder();
+
+        compute_encoder.set_compute_pipeline_state(&pipeline);
+        compute_encoder.set_buffer(0, Some(a), 0);
+        compute_encoder.set_buffer(1, Some(b), 0);
+        compute_encoder.set_buffer(2, Some(&result_buffer), 0);
+
+        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
+        compute_encoder.end_encoding();
+
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+
+        Ok(result_buffer)
+    }
+
+    pub fn log(&self, a: &Buffer, size: usize) -> Result<Buffer, MpsError> {
+        let result_buffer = self
+            .device
+            .device()
+            .new_buffer(
+                (size * std::mem::size_of::<f32>()) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+
+        // Create and compile the addition kernel
+        let library = self
+            .device
+            .device()
+            .new_library_with_source(
+                include_str!("../../../shaders/metal/binary_ops.metal"),
+                &metal::CompileOptions::new(),
+            )
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let kernel = library
+            .get_function("vector_log", None)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let pipeline = self
+            .device
+            .device()
+            .new_compute_pipeline_state_with_function(&kernel)
+            .map_err(|_| MpsError::ShaderCompilationError)?;
+
+        // Configure thread groups
+        let thread_group_size = MTLSize::new(256, 1, 1);
+        let grid_size = MTLSize::new(((size + 255) / 256) as u64, 1, 1);
+
+        let command_buffer = self.command_queue.new_command_buffer();
+        let compute_encoder = command_buffer.new_compute_command_encoder();
+
+        compute_encoder.set_compute_pipeline_state(&pipeline);
+        compute_encoder.set_buffer(0, Some(a), 0);
+        compute_encoder.set_buffer(1, Some(&result_buffer), 0);
+
+        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
+        compute_encoder.end_encoding();
+
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+
+        Ok(result_buffer)
+    }
+
+    pub fn get_supported_features(&self) -> DeviceFeatures {
+        let mut features = DeviceFeatures::new();
+
+        // Check MPS-specific features
+        features.add_feature(
+            GPU_FEATURE_FP16,
+            true, // MPS supports FP16
+            Some("Half-precision floating point support".to_string()),
+        );
+
+        features.add_feature(
+            GPU_FEATURE_FP64,
+            false, // MPS typically doesn't support FP64
+            Some("Double-precision floating point support".to_string()),
+        );
+
+        features
+    }
+
+    pub fn sum_backend(&self, input: &Buffer, size: usize) -> Result<Buffer, MpsError> {
+        let result_buffer = self.device.device().new_buffer(
+            (size * std::mem::size_of::<f32>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        let library = self.device.device().new_library_with_source(
+            include_str!("../../../shaders/metal/binary_ops.metal"),
+            &metal::CompileOptions::new(),
+        ).map_err(|_| MpsError::ShaderCompilationError)?;
+
+        let kernel = library.get_function("vector_sum", None).map_err(|_| MpsError::ShaderCompilationError)?;
+        let pipeline = self.device.device().new_compute_pipeline_state_with_function(&kernel).map_err(|_| MpsError::ShaderCompilationError)?;
+        let thread_group_size = MTLSize::new(1, 1, 1);
+        let grid_size = MTLSize::new(1, 1, 1);
+
+        let command_buffer = self.command_queue.new_command_buffer();
+        let compute_encoder = command_buffer.new_compute_command_encoder();
+
+        compute_encoder.set_compute_pipeline_state(&pipeline);
+        compute_encoder.set_buffer(0, Some(input), 0);
+        compute_encoder.set_buffer(1, Some(&result_buffer), 0);
+
+        compute_encoder.dispatch_thread_groups(grid_size, thread_group_size);
+        compute_encoder.end_encoding();
+
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+
+        Ok(result_buffer)
     }
 }
 

--- a/src/backend/mps/core.rs
+++ b/src/backend/mps/core.rs
@@ -45,7 +45,7 @@ impl MpsDevice {
         // Total operations = n * n * (2n - 1)
         let operations = size as u64 * size as u64 * (2 * size as u64 - 1);
         let flops = (operations as f64) / duration.as_secs_f64();
-
+        
         flops
     }
 }
@@ -57,7 +57,7 @@ mod tests {
     fn pretty_flops(flops: f64) -> String {
         if flops >= 1_000_000_000_000.0 {
             format!("{:.2} Tflops/s", flops / 1_000_000_000_000.0)
-        } else if flops >= 1_000_000_000.0 {
+        }else if flops >= 1_000_000_000.0 {
             format!("{:.2} Gflops/s", flops / 1_000_000_000.0)
         } else if flops >= 1_000_000.0 {
             format!("{:.2} Mflops/s", flops / 1_000_000.0)
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn test_calc_device_flops() {
-        let core = MpsDevice::new().unwrap;
+        let core = MpsDevice::new().unwrap();
         let flops = core.calc_device_flops();
         println!("{}", pretty_flops(flops));
 

--- a/src/tensor/creation.rs
+++ b/src/tensor/creation.rs
@@ -16,7 +16,7 @@ impl Tensor {
             #[cfg(feature = "cuda")]
             DeviceType::Cuda => Arc::new(CpuBackend::new()?),
             #[cfg(feature = "mps")]
-            DeviceType::Mps => Arc::new(CpuBackend::new()?),
+            DeviceType::Mps => Arc::new(MpsBackend::new()?),
             #[cfg(feature = "vulkan")]
             DeviceType::Vulkan => Arc::new(VulkanBackend::new()?),
         };
@@ -58,7 +58,7 @@ impl Tensor {
             #[cfg(feature = "cuda")]
             DeviceType::Cuda => Arc::new(CpuBackend::new()?),
             #[cfg(feature = "mps")]
-            DeviceType::Mps => Arc::new(CpuBackend::new()?),
+            DeviceType::Mps => Arc::new(MpsBackend::new()?),
             #[cfg(feature = "vulkan")]
             DeviceType::Vulkan => Arc::new(VulkanBackend::new()?),
         };
@@ -117,7 +117,7 @@ impl Tensor {
             #[cfg(feature = "cuda")]
             DeviceType::Cuda => Arc::new(CpuBackend::new()?),
             #[cfg(feature = "mps")]
-            DeviceType::Mps => Arc::new(CpuBackend::new()?),
+            DeviceType::Mps => Arc::new(MpsBackend::new()?),
             #[cfg(feature = "vulkan")]
             DeviceType::Vulkan => Arc::new(VulkanBackend::new()?),
         };
@@ -277,7 +277,7 @@ impl Tensor {
             #[cfg(feature = "cuda")]
             DeviceType::Cuda => Arc::new(CpuBackend::new()?),
             #[cfg(feature = "mps")]
-            DeviceType::Mps => Arc::new(CpuBackend::new()?),
+            DeviceType::Mps => Arc::new(MpsBackend::new()?),
             #[cfg(feature = "vulkan")]
             DeviceType::Vulkan => Arc::new(VulkanBackend::new()?),
         };


### PR DESCRIPTION
improve the MPS implements.

change the command queue create mechanism.

before improvement
command queue created on each tasks ( matmul, add, sum, etc... ).

after improvement
moved logic to communicate directly with Apple MPS to MpsCompute struct.
and create command queue once when MpsCompute initialized.

each tasks use one command queue in MpsCompute struct.

but it performs better when #6 issue solve
